### PR TITLE
Upgrade to Elasticsearch v5

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -3,11 +3,11 @@ elasticsearch_cluster_name: sample_cluster
 elasticsearch_network_host: 0.0.0.0
 elasticsearch_heap_size: "{{ (ansible_memory_mb.real.total/2) | int }}m"
 elasticsearch_node_name: "{{ inventory_hostname }}"
-elasticsearch_plugins:
-  - name: kopf
-    src: lmenezes/elasticsearch-kopf
-  - name: head
-    src: mobz/elasticsearch-head
+#elasticsearch_plugins:
+#  - name: kopf
+#    src: lmenezes/elasticsearch-kopf
+#  - name: head
+#    src: mobz/elasticsearch-head
 elasticsearch_jmxremote_port: 9020
 elasticsearch_java_opts: >-
   -Dcom.sun.management.jmxremote.port={{ elasticsearch_jmxremote_port }}

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -3,11 +3,6 @@ elasticsearch_cluster_name: sample_cluster
 elasticsearch_network_host: 0.0.0.0
 elasticsearch_heap_size: "{{ (ansible_memory_mb.real.total/2) | int }}m"
 elasticsearch_node_name: "{{ inventory_hostname }}"
-#elasticsearch_plugins:
-#  - name: kopf
-#    src: lmenezes/elasticsearch-kopf
-#  - name: head
-#    src: mobz/elasticsearch-head
 elasticsearch_jmxremote_port: 9020
 elasticsearch_java_opts: >-
   -Dcom.sun.management.jmxremote.port={{ elasticsearch_jmxremote_port }}
@@ -16,4 +11,4 @@ elasticsearch_java_opts: >-
   -Dcom.sun.management.jmxremote.ssl=false
   -Djava.rmi.server.hostname={% if vagrant_test_env %}{{ ansible_eth1.ipv4.address }}{% else %}{{ ansible_eth0.ipv4.address }}{% endif %}
 es_home: /usr/share/elasticsearch
-elasticsearch_version: 2.4.0
+elasticsearch_version: 5.0.0

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -22,12 +22,12 @@
   notify: restart elasticsearch
 
 - name: list plugins
-  shell: "{{ es_home }}/bin/plugin list | grep -v 'Installed plugins in'"
+  shell: "{{ es_home }}/bin/elasticsearch-plugin list | grep -v 'Installed plugins in'"
   register: installed_plugins
   changed_when: false
 
 - name: install elasticsearch plugins
-  shell: "{{ es_home }}/bin/plugin install {{ item.src }}"
+  shell: "{{ es_home }}/bin/elasticsearch-plugin install {{ item.src }}"
   with_items: "{{ elasticsearch_plugins }}"
   when: item.name not in installed_plugins.stdout
 
@@ -41,14 +41,14 @@
   command: "{{ es_home }}/bin/plugin install cloud-aws"
   when: aws_install is defined and aws_install and installed_plugin.stdout.find("cloud-aws") == -1
 
-- name: set elasticsearch JAVA_OPTS
-  lineinfile:
-    dest: /etc/default/elasticsearch
-    regexp: "^ES_JAVA_OPTS="
-    line: "ES_JAVA_OPTS=\"{{ elasticsearch_java_opts }}\""
-    insertafter: "^#ES_JAVA_OPTS"
-  notify: restart elasticsearch
-  when: elasticsearch_java_opts is defined
+#- name: set elasticsearch JAVA_OPTS
+#  lineinfile:
+#    dest: /etc/default/elasticsearch
+#    regexp: "^ES_JAVA_OPTS="
+#    line: "ES_JAVA_OPTS=\"{{ elasticsearch_java_opts }}\""
+#    insertafter: "^#ES_JAVA_OPTS"
+#  notify: restart elasticsearch
+#  when: elasticsearch_java_opts is defined
 
 - name: Start Elasticsearch.
   service: name=elasticsearch state=started enabled=yes

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -58,14 +58,14 @@
 
   when: aws_install is defined and aws_install
 
-#- name: set elasticsearch JAVA_OPTS
-#  lineinfile:
-#    dest: /etc/default/elasticsearch
-#    regexp: "^ES_JAVA_OPTS="
-#    line: "ES_JAVA_OPTS=\"{{ elasticsearch_java_opts }}\""
-#    insertafter: "^#ES_JAVA_OPTS"
-#  notify: restart elasticsearch
-#  when: elasticsearch_java_opts is defined
+- name: set elasticsearch JAVA_OPTS
+  lineinfile:
+    dest: /etc/default/elasticsearch
+    regexp: "^ES_JAVA_OPTS="
+    line: "ES_JAVA_OPTS=\"{{ elasticsearch_java_opts }}\""
+    insertafter: "^#ES_JAVA_OPTS"
+  notify: restart elasticsearch
+  when: elasticsearch_java_opts is defined
 
 - name: Start Elasticsearch.
   service: name=elasticsearch state=started enabled=yes

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -29,17 +29,34 @@
 - name: install elasticsearch plugins
   shell: "{{ es_home }}/bin/elasticsearch-plugin install {{ item.src }}"
   with_items: "{{ elasticsearch_plugins }}"
-  when: item.name not in installed_plugins.stdout
+  when: item.name not in installed_plugins.stdout and elasticsearch_plugins is defined
 
-- name: check if aws cloud plugin is installed
-  shell: >
-     {{ es_home }}/bin/plugin list cloud-aws | sed -n '1!p' | cut -d '-' -f2-
-  register: installed_plugin
+- block:
+  - block:
+    - name: check if aws cloud plugin is installed
+      shell: >
+         {{ es_home }}/bin/plugin list cloud-aws | sed -n '1!p' | cut -d '-' -f2-
+      register: installed_plugin
+
+    - name: install aws cloud plugin
+      command: "{{ es_home }}/bin/plugin install cloud-aws"
+      when: installed_plugin.stdout.find("cloud-aws") == -1
+    when: elasticsearch_version < 5
+##########################################################
+# cloud-aws plugin is updated to discovery-ec2 in elastic5
+###########################################################
+  - block:
+    - name: check if discovery ec2 plugin is installed
+      shell: >
+         {{ es_home }}/bin/elasticsearch-plugin list discovery-ec2 | sed -n '1!p' | cut -d '-' -f2-
+      register: installed_plugin
+
+    - name: install aws cloud plugin
+      command: "{{ es_home }}/bin/elasticsearch-plugin install discovery-ec2"
+      when: installed_plugin.stdout.find("discovery-ec2") == -1
+    when: elasticsearch_version > 5
+
   when: aws_install is defined and aws_install
-
-- name: install aws cloud plugin
-  command: "{{ es_home }}/bin/plugin install cloud-aws"
-  when: aws_install is defined and aws_install and installed_plugin.stdout.find("cloud-aws") == -1
 
 #- name: set elasticsearch JAVA_OPTS
 #  lineinfile:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -21,15 +21,18 @@
     group: elasticsearch
   notify: restart elasticsearch
 
-- name: list plugins
-  shell: "{{ es_home }}/bin/elasticsearch-plugin list | grep -v 'Installed plugins in'"
-  register: installed_plugins
-  changed_when: false
+- block:
+  - name: list plugins
+    shell: "{{ es_home }}/bin/elasticsearch-plugin list | grep -v 'Installed plugins in'"
+    register: installed_plugins
+    changed_when: false
 
-- name: install elasticsearch plugins
-  shell: "{{ es_home }}/bin/elasticsearch-plugin install {{ item.src }}"
-  with_items: "{{ elasticsearch_plugins }}"
-  when: item.name not in installed_plugins.stdout and elasticsearch_plugins is defined
+
+  - name: install elasticsearch plugins
+    shell: "{{ es_home }}/bin/elasticsearch-plugin install {{ item.src }}"
+    with_items: "{{ elasticsearch_plugins }}"
+    when: item.name not in installed_plugins.stdout
+  when: elasticsearch_plugins is defined
 
 - block:
   - block:

--- a/tasks/setup-Debian.yml
+++ b/tasks/setup-Debian.yml
@@ -6,7 +6,7 @@
 
 - name: Add Elasticsearch repository.
   apt_repository:
-    repo: 'deb http://packages.elastic.co/elasticsearch/2.x/debian stable main'
+    repo: 'deb https://artifacts.elastic.co/packages/5.x/apt stable main'
     state: present
     update_cache: yes
 
@@ -15,9 +15,12 @@
 
 - name: Set JVM heap size
   lineinfile:
-    dest: /etc/default/elasticsearch
-    regexp: "ES_HEAP_SIZE="
-    line: "ES_HEAP_SIZE={{ elasticsearch_heap_size }}"
+    dest: /etc/elasticsearch/jvm.options
+    regexp: "-{{ item }}"
+    line: "-{{ item }}{{ elasticsearch_heap_size }}"
   when: elasticsearch_heap_size is defined
+  with_items:
+    - Xms
+    - Xmx
   notify:
     - restart elasticsearch

--- a/templates/elasticsearch.yml.j2
+++ b/templates/elasticsearch.yml.j2
@@ -103,5 +103,3 @@ discovery.ec2.groups: {{ elasticsearch_security_group }}
 # Require explicit names when deleting indices:
 #
 # action.destructive_requires_name: true
-script.inline: on
-script.indexed: on

--- a/templates/elasticsearch.yml.j2
+++ b/templates/elasticsearch.yml.j2
@@ -77,8 +77,6 @@ network.host: {{ elasticsearch_network_host }}
 # <http://www.elastic.co/guide/en/elasticsearch/reference/current/modules-discovery.html>
 {% if aws_install is defined and aws_install -%}
 discovery.type: ec2
-discovery.zen.minimum_master_nodes: 1
-discovery.zen.ping.multicast.enabled: true
 cloud.node.auto_attributes: true
 cloud.aws.access_key: {{ aws_acces_key }}
 cloud.aws.secret_key: {{ aws_secret_key }}


### PR DESCRIPTION
- updated repo url
- move plugin tasks to blocks
- elasticsearch jvm size is now set in /etc/elasticsearch/jvm.options. 